### PR TITLE
CI: Add a weekly scheduled run

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - master
+  schedule:
+  - cron: '0 6 * * 1' # Run every Monday at 06:00 (UTC)
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - master
+  schedule:
+  - cron: '0 6 * * 1' # Run every Monday at 06:00 (UTC)
 
 name: test-coverage
 


### PR DESCRIPTION
Adds a weekly run to the CI jobs (each Monday at 06:00 UTC), so that breaking changes in the environment or dependencies don't go unnoticed. This prevents these breaking changes accumulating and showing up at a otherwise unrelated PR.