### PR TITLE
Return convergence diagnostics in addition to the flag indicating convergence

### DIFF
--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -528,7 +528,7 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #' @param precompute a boolean (defaulting to TRUE) deciding whether to
 #'   precompute quantities or not. Using TRUE will make the algorithm faster
 #'
-#' @return A list with three elements.
+#' @return A list with the following elements.
 #'   1) `epsilon` is a matrix containing the MCMC chain (thinned and after
 #'   burnin) for the relative transmissibility of the "new"
 #'   pathogen/strain/variant(s) compared to the reference
@@ -542,7 +542,9 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #'   Gelman-Rubin convergence diagnostic. This takes a value of TRUE
 #'   when the MCMC has converged within the number of iterations specified
 #'   and FALSE when the MCMC has not converged.
-#'   
+#'   4) `diag` is a list of the point estimate and upper confidence limits
+#'       of the Gelman-Rubin convergence diagnostics (as implemented in coda).
+#'
 #'
 #' @export
 #'
@@ -723,7 +725,7 @@ estimate_joint <- function(incid, si_distr, priors,
       }
     }
   }
-  
+
   # Add in convergence check (gelman diagnostic)
   # Split epsilon into 2 chains
 
@@ -736,25 +738,25 @@ estimate_joint <- function(incid, si_distr, priors,
     eps1 <- coda::as.mcmc(x[1:(length(x)/2)])
     eps2 <- coda::as.mcmc(x[(length(eps1)+1):length(x)])
   }
-  
+
   eps_2chain <- coda::mcmc.list(eps1,eps2)
   diag <- coda::gelman.diag(eps_2chain, confidence = 0.95)
-  
+
   # Are any of the scale reduction factors >1.1?
   if (any(diag$psrf[, "Upper C.I."] > 1.1)) {
-    message("The Gelman-Rubin algorithm suggests the MCMC may not have converged 
+    message("The Gelman-Rubin algorithm suggests the MCMC may not have converged
                  within the number of iterations specified.")
     convergence <- FALSE
   } else {
     convergence <- TRUE
-  } 
+  }
   convergence
   })
   ## TODO: Very importamt - do we need to fix
   ## ordering of R as well i.e. we have reshuffled the incidence
   ## but R should be returned in the order of the
   ## original incidence?
-  list(epsilon = epsilon_out, R = R_out, convergence = conv_check)
+  list(epsilon = epsilon_out, R = R_out, convergence = conv_check, diag = diag$psrf)
   # Not sure if this will be the same for >2 variants
 }
 

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -529,22 +529,28 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #'   precompute quantities or not. Using TRUE will make the algorithm faster
 #'
 #' @return A list with the following elements.
-#'   1) `epsilon` is a matrix containing the MCMC chain (thinned and after
+#' \enumerate{
+#'
+#'   \item `epsilon` is a matrix containing the MCMC chain (thinned and after
 #'   burnin) for the relative transmissibility of the "new"
 #'   pathogen/strain/variant(s) compared to the reference
 #'   pathogen/strain/variant. Each row in the matrix is a "new"
 #'   pathogen/strain/variant and each column an iteration of the MCMC.
-#'   2) `R` is an array containing the MCMC chain (thinned and after
+#'   \item `R` is an array containing the MCMC chain (thinned and after
 #'   burnin) for the reproduction number for the reference
 #'   pathogen/strain/variant. The first dimension of the array is time,
 #'   the second location, and the third iteration of the MCMC.
-#'   3) `convergence` is a logical vector based on the results of the
-#'   Gelman-Rubin convergence diagnostic. This takes a value of TRUE
-#'   when the MCMC has converged within the number of iterations specified
-#'   and FALSE when the MCMC has not converged.
-#'   4) `diag` is a list of the point estimate and upper confidence limits
-#'       of the Gelman-Rubin convergence diagnostics (as implemented in coda).
-#'
+#'   \item `convergence` is a logical vector based on the results of the
+#'   Gelman-Rubin convergence diagnostic. Each element in `convergence`
+#'   takes a value of TRUE
+#'   when the MCMC for the corresponding epsilon has converged within the
+#'   number of iterations specified and FALSE otherwise.
+#'   \item `diag` is a nested list of the point estimate and upper confidence limits
+#'       of the Gelman-Rubin convergence diagnostics (as implemented in coda). The length of
+#' `diag` is equal to the number of rows in `epsilon`. Each element of `diag` is a list of
+#' length 2 where the first element is called `psrf` and is a named list of the
+#' point estimate and upper confidence limits. The second elemnent is NULL and can be ignored.
+#'}
 #'
 #' @export
 #'
@@ -728,35 +734,41 @@ estimate_joint <- function(incid, si_distr, priors,
 
   # Add in convergence check (gelman diagnostic)
   # Split epsilon into 2 chains
+  diag <- lapply(
+    seq_len(nrow(epsilon_out)), function(row) {
+      x <- epsilon_out[row, ]
+      if(length(x)%%2 != 0){ # if length is odd
+        eps1 <- coda::as.mcmc(x[1:((length(x)+1)/2)])
+        eps2 <- coda::as.mcmc(x[length(eps1):length(x)])
+      }
+      if(length(x)%%2==0){ # if length is even
+        eps1 <- coda::as.mcmc(x[1:(length(x)/2)])
+        eps2 <- coda::as.mcmc(x[(length(eps1)+1):length(x)])
+      }
 
-  conv_check <- apply(epsilon_out, 1, function(x) {
-  if(length(x)%%2!=0){ # if length is odd
-    eps1 <- coda::as.mcmc(x[1:((length(x)+1)/2)])
-    eps2 <- coda::as.mcmc(x[length(eps1):length(x)])
-  }
-  if(length(x)%%2==0){ # if length is even
-    eps1 <- coda::as.mcmc(x[1:(length(x)/2)])
-    eps2 <- coda::as.mcmc(x[(length(eps1)+1):length(x)])
-  }
+      eps_2chain <- coda::mcmc.list(eps1,eps2)
+      coda::gelman.diag(eps_2chain, confidence = 0.95)
 
-  eps_2chain <- coda::mcmc.list(eps1,eps2)
-  diag <- coda::gelman.diag(eps_2chain, confidence = 0.95)
-
+    }
+  )
+  conv_check <- lapply(diag, function(x) {
   # Are any of the scale reduction factors >1.1?
-  if (any(diag$psrf[, "Upper C.I."] > 1.1)) {
-    message("The Gelman-Rubin algorithm suggests the MCMC may not have converged
-                 within the number of iterations specified.")
-    convergence <- FALSE
-  } else {
-    convergence <- TRUE
+   if (any(x$psrf[, "Upper C.I."] > 1.1)) {
+     message("The Gelman-Rubin algorithm suggests the MCMC may not have converged
+                  within the number of iterations specified.")
+     convergence <- FALSE
+   } else {
+     convergence <- TRUE
+   }
+    convergence
   }
-  convergence
-  })
+  )
+  conv_check <- unlist(conv_check)
   ## TODO: Very importamt - do we need to fix
   ## ordering of R as well i.e. we have reshuffled the incidence
   ## but R should be returned in the order of the
   ## original incidence?
-  list(epsilon = epsilon_out, R = R_out, convergence = conv_check, diag = diag$psrf)
+  list(epsilon = epsilon_out, R = R_out, convergence = conv_check, diag = diag)
   # Not sure if this will be the same for >2 variants
 }
 

--- a/man/estimate_joint.Rd
+++ b/man/estimate_joint.Rd
@@ -62,21 +62,28 @@ precompute quantities or not. Using TRUE will make the algorithm faster}
 }
 \value{
 A list with the following elements.
-  1) `epsilon` is a matrix containing the MCMC chain (thinned and after
+\enumerate{
+
+  \item `epsilon` is a matrix containing the MCMC chain (thinned and after
   burnin) for the relative transmissibility of the "new"
   pathogen/strain/variant(s) compared to the reference
   pathogen/strain/variant. Each row in the matrix is a "new"
   pathogen/strain/variant and each column an iteration of the MCMC.
-  2) `R` is an array containing the MCMC chain (thinned and after
+  \item `R` is an array containing the MCMC chain (thinned and after
   burnin) for the reproduction number for the reference
   pathogen/strain/variant. The first dimension of the array is time,
   the second location, and the third iteration of the MCMC.
-  3) `convergence` is a logical vector based on the results of the
-  Gelman-Rubin convergence diagnostic. This takes a value of TRUE
-  when the MCMC has converged within the number of iterations specified
-  and FALSE when the MCMC has not converged.
-  4) `diag` is a list of the point estimate and upper confidence limits
-      of the Gelman-Rubin convergence diagnostics (as implemented in coda).
+  \item `convergence` is a logical vector based on the results of the
+  Gelman-Rubin convergence diagnostic. Each element in `convergence`
+  takes a value of TRUE
+  when the MCMC for the corresponding epsilon has converged within the
+  number of iterations specified and FALSE otherwise.
+  \item `diag` is a nested list of the point estimate and upper confidence limits
+      of the Gelman-Rubin convergence diagnostics (as implemented in coda). The length of
+`diag` is equal to the number of rows in `epsilon`. Each element of `diag` is a list of
+length 2 where the first element is called `psrf` and is a named list of the
+point estimate and upper confidence limits. The second elemnent is NULL and can be ignored.
+}
 }
 \description{
 Jointly estimate the instantaneous reproduction number for a reference

--- a/man/estimate_joint.Rd
+++ b/man/estimate_joint.Rd
@@ -61,7 +61,7 @@ time step will be considered locally infected.}
 precompute quantities or not. Using TRUE will make the algorithm faster}
 }
 \value{
-A list with three elements.
+A list with the following elements.
   1) `epsilon` is a matrix containing the MCMC chain (thinned and after
   burnin) for the relative transmissibility of the "new"
   pathogen/strain/variant(s) compared to the reference
@@ -75,6 +75,8 @@ A list with three elements.
   Gelman-Rubin convergence diagnostic. This takes a value of TRUE
   when the MCMC has converged within the number of iterations specified
   and FALSE when the MCMC has not converged.
+  4) `diag` is a list of the point estimate and upper confidence limits
+      of the Gelman-Rubin convergence diagnostics (as implemented in coda).
 }
 \description{
 Jointly estimate the instantaneous reproduction number for a reference

--- a/tests/testthat/test-multivariant-input.R
+++ b/tests/testthat/test-multivariant-input.R
@@ -25,7 +25,7 @@ test_that("si_distr is specified correctly", {
   expect_error(compute_lambda(incid=incid_processed, si_distr=sidistr_3),
                "si_distr must be >=0")
 })
-  
+
 ##############################
 ## Tests for draw_epsilon() ##
 ##############################
@@ -41,7 +41,7 @@ priors <- default_priors()
 tmin1 <- 2.5 # not an integer
 tmin2 <- 1L # less than 2
 tmin3 <- as.integer(nrow(incid)+1) # greater than nrow(incid)
-  
+
 test_that("tmin and tmax are specified correctly", {
   expect_error(draw_epsilon(R=R, incid=incid, lambda=lambda, priors=priors,
                               t_min = tmin1, t_max = nrow(incid),
@@ -273,8 +273,8 @@ test_that("convergence check returns FALSE for non-converging MCMC", {
                         mcmc_control = low_iter(),
                         t_min = 2L, t_max = nrow(incid),
                         seed = NULL)
-  
-  expect_equal(out$convergence, FALSE)
+
+  expect_false(out$convergence[1])
 })
 
 test_that("convergence check returns TRUE for converging MCMC", {
@@ -282,8 +282,8 @@ test_that("convergence check returns TRUE for converging MCMC", {
                         mcmc_control = high_iter(),
                         t_min = 2L, t_max = nrow(incid),
                         seed = NULL)
-  
-  expect_equal(out$convergence, TRUE)
+
+  expect_true(out$convergence[1])
 })
 
 

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -848,3 +848,28 @@ test_that("estimate_joint uses the correct t_min", {
   expect_true(! any(is.na(x$R[seq(t_min, dim(x$R)[1]), , ])))
 })
 
+
+
+test_that("estimate_joint convergence checks work with >2 variants", {
+  n_v <- 3 # 3 variants
+  n_loc <- 4 # 4 locations
+  T <- 100 # 100 time steps
+
+  priors <- default_priors()
+
+  # constant incidence 10 per day everywhere
+  incid <- array(10, dim = c(T, n_loc, n_v))
+
+  # arbitrary serial interval
+  w_v <- c(0, 0.2, 0.5, 0.3)
+  si_distr <- cbind(w_v, w_v, w_v)
+  low_iter <- list(n_iter = 60L, burnin = 10L, thin = 1L)
+  x <- estimate_joint(
+    incid, si_distr, priors, seed = 1, t_min = 2L, mcmc_control = low_iter
+  )
+  ## convergence should be a list of length 2.
+  ## not checking whether chains have converged or not.
+  ## that is tested in a different set of tests.
+  expect_equal(length(x$convergence), 2)
+  expect_equal(length(x$diag), 2)
+})


### PR DESCRIPTION
I have
- edited the estimate_joint function to return the diagnostics in addition to the convergence flags being returned
- edited the convergence tests because the convergence flag is a vector rather than a single logical.
- added a test for more than 2 variants i.e. when we estimate more than 1 epsilon value.
- improved the documentation to use a numbered list.

All tests pass OK