### PR TITLE
Set up static code analysis with lintr and fix lints

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,14 @@
+linters: linters_with_tags(
+    tags = c("best_practices", "common_mistakes", "correctness", "efficiency", "robustness"),
+    undesirable_function_linter = NULL,
+    implicit_integer_linter = NULL,
+    extraction_operator_linter = NULL,
+    commented_code_linter = NULL,
+    cyclocomp_linter = NULL,
+    nonportable_path_linter = NULL,
+    missing_package_linter = NULL,
+    implicit_assignment_linter = NULL, 
+    function_argument_linter = NULL,
+    T_and_F_symbol_linter = NULL,
+    unused_import_linter = NULL
+  )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Tools to quantify transmissibility throughout
     <doi:10.1093/aje/kwh255>.
 URL: https://github.com/mrc-ide/EpiEstim
 BugReports: https://github.com/mrc-ide/EpiEstim/issues
-Depends: R (>= 2.10)
+Depends: R (>= 3.3.0)
 Imports:
     coarseDataTools (>= 0.6-4),
     stats,

--- a/R/aggregate_inc.R
+++ b/R/aggregate_inc.R
@@ -25,7 +25,7 @@
 aggregate_inc <- function(incid, dt = 7L)
 {
   if(all(dt < 2)) {stop("at least one value of dt should be an integer >=2")}
-  if(any(!is.integer(dt))) {stop("dt should be an integer or vector of integers e.g. 2L or c(2L,2L,3L)")}
+  if(!all(is.integer(dt))) {stop("dt should be an integer or vector of integers e.g. 2L or c(2L,2L,3L)")}
   if(!is.vector(incid)) {stop("incid should be a vector of integer values")}
   
   ndays <- length(incid)

--- a/R/aggregate_inc.R
+++ b/R/aggregate_inc.R
@@ -46,7 +46,7 @@ aggregate_inc <- function(incid, dt = 7L)
   
   agg_inc <- numeric(length = length(start))
   
-  for (i in 1:length(start)){
+  for (i in seq_along(start)){
     agg_inc[i] <- sum(incid[start[i]:end[i]])
   }
   

--- a/R/estimate_R.R
+++ b/R/estimate_R.R
@@ -555,7 +555,7 @@ estimate_R_func <- function(incid,
     si_uncertainty <- "Y"
     parametric_si <- "Y"
   }
-  if (method == "si_from_data" | method == "si_from_sample") {
+  if (method %in% c("si_from_data", "si_from_sample")) {
     si_uncertainty <- "Y"
     parametric_si <- "N"
   }

--- a/R/estimate_R.R
+++ b/R/estimate_R.R
@@ -592,7 +592,7 @@ estimate_R_func <- function(incid,
                                                                       mean_si_sample[k])] <- (temp[[k]])[[1]][, which(config$t_end >
                                                                                                                         mean_si_sample[k])]
       }
-      mean_posterior <- apply(r_sample, 2, mean, na.rm = TRUE)
+      mean_posterior <- colMeans(r_sample, na.rm = TRUE)
       std_posterior <- apply(r_sample, 2, sd, na.rm = TRUE)
       quantile_0.025_posterior <- apply(r_sample, 2, quantile,
                                         0.025,
@@ -647,7 +647,7 @@ estimate_R_func <- function(incid,
                                                                      mean_si_sample[k])] <- (temp[[k]])[[1]][, which(config$t_end >
                                                                                                                        mean_si_sample[k])]
       }
-      mean_posterior <- apply(r_sample, 2, mean, na.rm = TRUE)
+      mean_posterior <- colMeans(r_sample, na.rm = TRUE)
       std_posterior <- apply(r_sample, 2, sd, na.rm = TRUE)
       quantile_0.025_posterior <- apply(r_sample, 2, quantile,
                                         0.025,

--- a/R/estimate_R_agg.R
+++ b/R/estimate_R_agg.R
@@ -237,7 +237,7 @@ estimate_R_agg <- function(incid,
   if (iter < 2L) {
     stop ("iter must be at least 2L")
   }
-  if (!is.list(grid) | !length(grid) == 3){
+  if (!is.list(grid) || !length(grid) == 3){
     stop ("grid must be a list of 3 elements: precision, min, and max")
   }
   if (grid$max < grid$min){
@@ -246,7 +246,7 @@ estimate_R_agg <- function(incid,
   if (grid$precision > grid$max-grid$min){
     stop ("grid precision must be less than grid max - grid min")
   }
-  if (!is.numeric(grid$precision) | !is.numeric(grid$min) | !is.numeric(grid$max)){
+  if (!is.numeric(grid$precision) || !is.numeric(grid$min) || !is.numeric(grid$max)){
     stop ("grid precision, min, and max, must all be numeric")
   }
   if (!method == "parametric_si" && !method == "non_parametric_si"){

--- a/R/estimate_R_agg.R
+++ b/R/estimate_R_agg.R
@@ -322,7 +322,7 @@ estimate_R_agg <- function(incid,
       message("Estimated R for iteration: ", i)
       Mean_R <- R$R$`Mean(R)`
       
-      if (any(is.na(Mean_R))){
+      if (anyNA(Mean_R)){
         idx_na <- which(is.na(Mean_R))
         idx_reconstruct <- seq(min(R$R$t_start[-idx_na]), length(dis_inc))
         Mean_R <- Mean_R[!is.na(Mean_R)]
@@ -440,7 +440,7 @@ estimate_R_agg <- function(incid,
       
       Mean_R <- R$R$`Mean(R)`
       
-      if (any(is.na(Mean_R))){
+      if (anyNA(Mean_R)){
         idx_na <- which(is.na(Mean_R))
         idx_reconstruct <- seq(min(R$R$t_start[-idx_na]), length(dis_inc))
         Mean_R <- Mean_R[!is.na(Mean_R)]

--- a/R/estimate_R_agg.R
+++ b/R/estimate_R_agg.R
@@ -296,7 +296,7 @@ estimate_R_agg <- function(incid,
   niter <- seq(1, iter, 1) 
   sim_inc <- matrix(NA, nrow = T, ncol = iter)
   
-  for (i in 1:length(niter)){
+  for (i in seq_along(niter)){
     if (niter[i] == 1){
       # Initialisation of EM. Aggregated incidence split evenly:
       if (length(dt) == 1){
@@ -381,7 +381,7 @@ estimate_R_agg <- function(incid,
       k <- numeric(length(aggs_to_reconstruct))
       dt_seq <- full_dt[aggs_to_reconstruct]
       
-      for (w in 1:length(k)){
+      for (w in seq_along(k)){
         if (dt_seq[w] > 1){
         d[w] <- sum(exp(gr[w] * seq(1, dt_seq[w] - 1, 1)))
         k[w] <- incid_to_reconstruct[w] / (exp(gr[w]) * (1 + d[w]))
@@ -396,7 +396,7 @@ estimate_R_agg <- function(incid,
       k_ls <- list()
       gr_ls <- list()
       
-      for (f in 1:length(incid_to_reconstruct)){
+      for (f in seq_along(incid_to_reconstruct)){
         k_ls[[f]] <- rep(recon_df$k[f], recon_df$dt[f])
         gr_ls[[f]] <- rep(recon_df$gr[f], recon_df$dt[f])
       }
@@ -406,7 +406,7 @@ estimate_R_agg <- function(incid,
       recon_days <- seq(1, sum(dt_seq))
       w_day <- list()
 
-      for (x in 1:length(dt_seq)){
+      for (x in seq_along(dt_seq)){
         w_day[[x]] <- seq(1,dt_seq[x])
       }
 
@@ -466,7 +466,7 @@ estimate_R_agg <- function(incid,
       k <- numeric(length(aggs_to_reconstruct))
       dt_seq <- full_dt[aggs_to_reconstruct]
       
-      for (w in 1:length(k)){
+      for (w in seq_along(k)){
         if (dt_seq[w] > 1){
           d[w] <- sum(exp(gr[w] * seq(1, dt_seq[w] - 1, 1)))
           k[w] <- incid_to_reconstruct[w] / (exp(gr[w]) * (1 + d[w]))
@@ -481,7 +481,7 @@ estimate_R_agg <- function(incid,
       k_ls <- list()
       gr_ls <- list()
       
-      for (f in 1:length(incid_to_reconstruct)){
+      for (f in seq_along(incid_to_reconstruct)){
         k_ls[[f]] <- rep(recon_df$k[f], recon_df$dt[f])
         gr_ls[[f]] <- rep(recon_df$gr[f], recon_df$dt[f])
       }
@@ -489,7 +489,7 @@ estimate_R_agg <- function(incid,
       gr_seq <- unlist(gr_ls)
       
       w_day <- list()
-      for (x in 1:length(dt_seq)){
+      for (x in seq_along(dt_seq)){
         w_day[[x]] <- seq(1 , dt_seq[x])
       }
       w_day <- unlist(w_day)

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -738,16 +738,14 @@ estimate_advantage <- function(incid, si_distr, priors = default_priors(),
   ## IF we have not re-ordered, we don't need to
   ## divide. Caution: this will only work for
   ## 2 variants at the moment.
-  if (reorder_incid) {
-    if (max_transmiss != 1) {
-      epsilon_out[1 , ] <-  1 / epsilon_out[1 , ]
-      if (nrow(epsilon_out) > 1) {
-        for (row in 2:nrow(epsilon_out)) {
-          epsilon_out[row, ] <- epsilon_out[row, ] *  epsilon_out[1, ]
-        }
+  if (reorder_incid && max_transmiss != 1) {
+    epsilon_out[1 , ] <-  1 / epsilon_out[1 , ]
+    if (nrow(epsilon_out) > 1) {
+      for (row in 2:nrow(epsilon_out)) {
+        epsilon_out[row, ] <- epsilon_out[row, ] *  epsilon_out[1, ]
       }
-      R_out <- R_out / as.vector(epsilon_out)
     }
+    R_out <- R_out / as.vector(epsilon_out)
   }
   
   # Add in convergence check (gelman diagnostic)

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -187,9 +187,9 @@ default_mcmc_controls <- function() {
 
 compute_lambda <- function(incid, si_distr) {
   if (!inherits(incid, "incid_multivariant")) {
-    msg1 <- "'incid 'should be an 'incid_multivariant' object."
+    msg1 <- "'incid 'should be an 'incid_multivariant' object. "
     msg2 <- "Use function 'process_I_multivariant' first"
-    stop(paste(msg1, msg2))
+    stop(msg1, msg2)
   }
   if (any(si_distr[1,] != 0)){
     stop("Values in the first row of si_distr must be 0")

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -279,19 +279,19 @@ draw_epsilon <- function(R, incid, lambda, priors,
                          shape_epsilon = NULL,
                          t_min = 2L, t_max = nrow(incid),
                          seed = NULL) {
-  if (!is.integer(t_min) | !is.integer(t_max)){
+  if (!is.integer(t_min) || !is.integer(t_max)){
     stop("t_min and t_max must be integers")
   }
-  if (t_min < 2 | t_max < 2){
+  if (t_min < 2 || t_max < 2){
     stop("t_min and t_max must be >=2")
   }
-  if(t_min > nrow(incid) | t_max > nrow(incid)){
+  if(t_min > nrow(incid) || t_max > nrow(incid)){
     stop("t_min and t_max must be <= nrow(incid)")
   }
   if(any(R[!is.na(R)] < 0)) {
     stop("R must be >= 0")
   }
-  if (!is.null(seed) & !is.numeric(seed)){
+  if (!is.null(seed) && !is.numeric(seed)){
     stop("seed must be numeric")
   }
   if (!is.null(seed)) set.seed(seed)
@@ -373,19 +373,19 @@ draw_R <- function(epsilon, incid, lambda, priors,
                    shape_R_flat = NULL,
                    t_min = NULL, t_max = nrow(incid),
                    seed = NULL) {
-  if (!is.integer(t_min) | !is.integer(t_max)){
+  if (!is.integer(t_min) || !is.integer(t_max)){
     stop("t_min and t_max must be integers")
   }
-  if (t_min < 2 | t_max < 2){
+  if (t_min < 2 || t_max < 2){
     stop("t_min and t_max must be >=2")
   }
-  if(t_min > nrow(incid) | t_max > nrow(incid)){
+  if(t_min > nrow(incid) || t_max > nrow(incid)){
     stop("t_min and t_max must be <= nrow(incid)")
   }
   if (any(epsilon < 0)){
     stop("epsilon must be > 0")
   }
-  if (!is.null(seed) & !is.numeric(seed)){
+  if (!is.null(seed) && !is.numeric(seed)){
     stop("seed must be numeric")
   }
   if (!is.null(seed)) set.seed(seed)
@@ -606,13 +606,13 @@ estimate_advantage <- function(incid, si_distr, priors = default_priors(),
   if (is.null(t_min)) {
     t_min <- compute_t_min(incid, si_distr)
   }
-  if (!is.integer(t_min) | !is.integer(t_max)) {
+  if (!is.integer(t_min) || !is.integer(t_max)) {
     stop("t_min and t_max must be integers")
   }
-  if (t_min < 2 | t_max < 2){
+  if (t_min < 2 || t_max < 2){
     stop("t_min and t_max must be >=2")
   }
-  if(t_min > nrow(incid) | t_max > nrow(incid)){
+  if(t_min > nrow(incid) || t_max > nrow(incid)){
     stop("t_min and t_max must be <= nrow(incid)")
   }
   if (any(si_distr[1,] != 0)){
@@ -624,19 +624,19 @@ estimate_advantage <- function(incid, si_distr, priors = default_priors(),
   if (any(si_distr < 0)){
     stop("si_distr must be >=0")
   }
-  if (mcmc_control$n_iter < 0 | !is.integer(mcmc_control$n_iter)){
+  if (mcmc_control$n_iter < 0 || !is.integer(mcmc_control$n_iter)){
     stop("n_iter in mcmc_control must be a positive integer")
   }
-  if (mcmc_control$burnin < 0 | !is.integer(mcmc_control$burnin)){
+  if (mcmc_control$burnin < 0 || !is.integer(mcmc_control$burnin)){
     stop("burnin in mcmc_control must be a positive integer")
   }
-  if (mcmc_control$thin < 0 | !is.integer(mcmc_control$thin)){
+  if (mcmc_control$thin < 0 || !is.integer(mcmc_control$thin)){
     stop("thin in mcmc_control must be a positive integer")
   }
   if (mcmc_control$n_iter < mcmc_control$burnin + mcmc_control$thin){
     stop("In mcmc_control, n_iter must be greater than burnin + thin")
   }
-  if (!is.null(seed) & !is.numeric(seed)){
+  if (!is.null(seed) && !is.numeric(seed)){
     stop("seed must be numeric")
   }
   if (!is.null(seed)) set.seed(seed)

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -454,7 +454,7 @@ first_nonzero_incid <- function(incid) {
     incid, c(2, 3),
     function(vec) Position(function(x) x > 0, vec)
   )
-  if (any(is.na(t_min_incid))) {
+  if (anyNA(t_min_incid)) {
     warning(
       "For some variants/locations, incidence is
        always zero. This will cause estimate_advantage to fail."

--- a/R/init_mcmc_params.R
+++ b/R/init_mcmc_params.R
@@ -146,7 +146,7 @@ init_mcmc_params <- function(si_data,
   } else {
     stop(sprintf("Distribtion (%s) not supported", dist))
   }
-  if (any(is.na(param))) {
+  if (anyNA(param)) {
     stop("NA result. Check that si_data is in the right format. ")
   }
   return(param)

--- a/R/plot.R
+++ b/R/plot.R
@@ -329,7 +329,7 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
         }
 
         if (is.null(options_R$ylim)) {
-          options_R$ylim <- c(0, max(df[, grep("upper", names(df))],
+          options_R$ylim <- c(0, max(df[, grep("upper", names(df), fixed = TRUE)],
                                      na.rm = TRUE))
         }
 
@@ -423,7 +423,7 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
         }
 
         if (is.null(options_R$ylim)) {
-          options_R$ylim <- c(0, max(df[, grep("upper", names(df))],
+          options_R$ylim <- c(0, max(df[, grep("upper", names(df), fixed = TRUE)],
                                      na.rm = TRUE))
         }
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -227,8 +227,7 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
   si_distr.1 <- NULL
   ########################################################################
 
-  if (method == "uncertain_si" | method == "si_from_data" |
-      method == "si_from_sample") {
+  if (method %in% c("uncertain_si", "si_from_data", "si_from_sample")) {
     mean_si.sample <- x$SI.Moments["Mean"]
     std_si.sample <- x$SI.Moments["Std"]
   }
@@ -239,7 +238,7 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
   }
   ## TODO: change plot to allow for non-integer incidence
   what <- match.arg(what)
-  if (what == "incid" | what == "all") {
+  if (what %in% c("incid", "all")) {
     if (add_imported_cases) {
       p1 <- plot(as.incidence(incid, dates = x$dates, 
                               interval = options_I$interval),
@@ -262,7 +261,7 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
       p1 <- p1 + lims(y = options_I$ylim)
     }
   }
-  if (what == "R" | what == "all") {
+  if (what %in% c("R", "all")) {
     time.points <- apply(x$R[, c("t_start", "t_end") ], 1, function(x) 
       seq(x[1], x[2] - 1))
     if (length(time.points) == length(unique(matrix(time.points, ncol = 1)))) {
@@ -458,9 +457,8 @@ plot.estimate_R <- function(x, what = c("all", "incid", "R", "SI"),
       }
     }
   }
-  if (what == "SI" | what == "all") {
-    if (method == "uncertain_si" | method == "si_from_data" |
-        method == "si_from_sample") {
+  if (what %in% c("SI", "all")) {
+    if (method %in% c("uncertain_si", "si_from_data", "si_from_sample")) {
       tmp <- cumsum(apply(si_distr, 2, max) >= options_SI$prob_min)
       stop_at <- min(which(tmp == tmp[length(tmp)]))
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -70,10 +70,8 @@ process_I <- function(incid) {
   single_col_df_I <- FALSE
   if (is.vector(incid)) {
     vector_I <- TRUE
-  } else if (is.data.frame(incid)) {
-    if (ncol(incid) == 1) {
-      single_col_df_I <- TRUE
-    }
+  } else if (is.data.frame(incid) && ncol(incid) == 1) {
+    single_col_df_I <- TRUE
   }
   if (vector_I || single_col_df_I) {
     if (single_col_df_I) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -443,7 +443,7 @@ vcapply <- function(X, FUN, ...) {
 modify_defaults <- function(defaults, x, strict = TRUE) {
   extra <- setdiff(names(x), names(defaults))
   if (strict && (length(extra) > 0L)) {
-    stop("Additional invalid options: ", paste(extra, collapse=", "))
+    stop("Additional invalid options: ", toString(extra))
   }
   utils::modifyList(defaults, x, keep.null = TRUE) # keep.null is needed here
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -209,8 +209,8 @@ check_si_distr <- function(si_distr, sumToOne = c("error", "warning"),
 {
   sumToOne <- match.arg(sumToOne)
   if (is.null(si_distr)) {
-    stop(paste0("si_distr argument is missing but is required for method ", 
-                method, "."))
+    stop("si_distr argument is missing but is required for method ",
+         method, ".")
   }
   if (!is.vector(si_distr)) {
     stop("si_distr must be a vector.")
@@ -296,11 +296,11 @@ process_config_si_from_data <- function(config, si_data) {
     config$si_parametric_distr == "off1W" ||
     config$si_parametric_distr == "off1L") &&
     any(si_data$SR - si_data$EL <= 1)) {
-    stop(paste(
-      "You cannot fit a distribution with offset 1 to this SI",
-      "dataset, because for some data points the maximum serial",
+    stop(
+      "You cannot fit a distribution with offset 1 to this SI ",
+      "dataset, because for some data points the maximum serial ",
       "interval is <=1.\nChoose a different distribution"
-    ))
+    )
   }
   return(config)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -48,7 +48,7 @@ process_si_data <- function(si_data) {
     warning("si_data contains no 'type' column. This is inferred automatically 
             from the other columns.")
     si_data$type <- tmp_type
-  } else if (any(is.na(si_data$type)) | !all(si_data$type == tmp_type)) {
+  } else if (any(is.na(si_data$type)) || !all(si_data$type == tmp_type)) {
     warning("si_data contains unexpected entries in the 'type' column. This is 
             inferred automatically from the other columns.")
     si_data$type <- tmp_type
@@ -75,7 +75,7 @@ process_I <- function(incid) {
       single_col_df_I <- TRUE
     }
   }
-  if (vector_I | single_col_df_I) {
+  if (vector_I || single_col_df_I) {
     if (single_col_df_I) {
       I_tmp <- incid[[1]]
     } else {
@@ -85,13 +85,13 @@ process_I <- function(incid) {
     I_init     <- sum(incid[1, ])
     incid[1, ] <- c(0, I_init)
   } else {
-    if (!is.data.frame(incid) | 
-        (!("I" %in% names(incid)) &
+    if (!is.data.frame(incid) || 
+        (!("I" %in% names(incid)) &&
          !all(c("local", "imported") %in% names(incid)))) {
       stop("incid must be a vector or a dataframe with either i) a column 
            called 'I', or ii) 2 columns called 'local' and 'imported'.")
     }
-    if (("I" %in% names(incid)) & 
+    if (("I" %in% names(incid)) && 
         !all(c("local", "imported") %in% names(incid))) {
       incid$local    <- incid$I
       incid$local[1] <- 0
@@ -233,7 +233,7 @@ check_si_distr <- function(si_distr, sumToOne = c("error", "warning"),
 
 check_dates <- function(incid) {
   dates <- incid$dates
-  if (class(dates) != "Date" & class(dates) != "numeric") {
+  if (class(dates) != "Date" && class(dates) != "numeric") {
     stop("incid$dates must be an object of class date or numeric.")
   } else {
     if (unique(diff(dates)) != 1) {
@@ -292,9 +292,9 @@ process_config_si_from_data <- function(config, si_data) {
     config$mcmc_control$init_pars <-
       init_mcmc_params(si_data, config$si_parametric_distr)
   }
-  if ((config$si_parametric_distr == "off1G" |
-    config$si_parametric_distr == "off1W" |
-    config$si_parametric_distr == "off1L") &
+  if ((config$si_parametric_distr == "off1G" ||
+    config$si_parametric_distr == "off1W" ||
+    config$si_parametric_distr == "off1L") &&
     any(si_data$SR - si_data$EL <= 1)) {
     stop(paste(
       "You cannot fit a distribution with offset 1 to this SI",

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -21,7 +21,7 @@ process_si_data <- function(si_data) {
   }
 
   # non integer entries in date columns
-  if (!all(vlapply(seq_len(4), function(e) class(si_data[, e]) == "integer"))) {
+  if (!all(vlapply(seq_len(4), function(e) is.integer(si_data[, e])))) {
     stop("si_data has entries for which EL, ER, SL or SR are non integers.")
   }
 
@@ -233,7 +233,7 @@ check_si_distr <- function(si_distr, sumToOne = c("error", "warning"),
 
 check_dates <- function(incid) {
   dates <- incid$dates
-  if (class(dates) != "Date" && class(dates) != "numeric") {
+  if (!inherits(dates, "Date") && !is.numeric(dates)) {
     stop("incid$dates must be an object of class date or numeric.")
   } else {
     if (unique(diff(dates)) != 1) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -48,7 +48,7 @@ process_si_data <- function(si_data) {
     warning("si_data contains no 'type' column. This is inferred automatically 
             from the other columns.")
     si_data$type <- tmp_type
-  } else if (any(is.na(si_data$type)) || !all(si_data$type == tmp_type)) {
+  } else if (anyNA(si_data$type) || !all(si_data$type == tmp_type)) {
     warning("si_data contains unexpected entries in the 'type' column. This is 
             inferred automatically from the other columns.")
     si_data$type <- tmp_type

--- a/R/wallinga_teunis.R
+++ b/R/wallinga_teunis.R
@@ -123,7 +123,7 @@ wallinga_teunis <- function(incid,
     res <- vector()
     for (t in seq_len(T))
     {
-      if (length(which(Onset == t)) > 0) {
+      if (any(Onset == t)) {
         if (length(possible_ances_time[[t]]) > 0) {
           prob <- config$si_distr[t - possible_ances_time[[t]] + 1] *
             incid[possible_ances_time[[t]]]

--- a/R/wallinga_teunis.R
+++ b/R/wallinga_teunis.R
@@ -131,8 +131,8 @@ wallinga_teunis <- function(incid,
           if (any(prob > 0)) {
             res[ot] <-
               possible_ances_time[[t]][which(rmultinom(length(ot),
-                                                       size = 1, prob = prob)
-                                             == TRUE, arr.ind = TRUE)[, 1]]
+                                                       size = 1, prob = prob) 
+                                             == 1, arr.ind = TRUE)[, 1]]
           } else {
             res[ot] <- NA
           }

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -870,8 +870,8 @@ test_that("estimate_advantage convergence checks work with >2 variants", {
   ## convergence should be a list of length 2.
   ## not checking whether chains have converged or not.
   ## that is tested in a different set of tests.
-  expect_equal(length(x$convergence), 2)
-  expect_equal(length(x$diag), 2)
+  expect_length(x$convergence, 2)
+  expect_length(x$diag, 2)
 })
 
 test_that("estimate_advantage produces expected warning message", {

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -839,13 +839,13 @@ test_that("estimate_advantage uses the correct t_min", {
   ## If t_min is 2, the first row if x$R will be NA
   expect_true(all(is.na(x$R[1, , ])))
   ## and not after that.
-  expect_true(! anyNA(x$R[seq(2, dim(x$R)[1]), , ]))
+  expect_false(anyNA(x$R[seq(2, dim(x$R)[1]), , ]))
   ## if t_min is NULL, t_min would be set to
   ## compute_t_min.
   t_min <- compute_t_min(incid, si_distr)
   x <- estimate_advantage(incid, si_distr, priors, seed = 1)
   expect_true(all(is.na(x$R[seq(1, t_min - 1, 1), , ])))
-  expect_true(! anyNA(x$R[seq(t_min, dim(x$R)[1]), , ]))
+  expect_false(anyNA(x$R[seq(t_min, dim(x$R)[1]), , ]))
 })
 
 

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -84,7 +84,7 @@ test_that("draw_epsilon produces expected results (>2 variants, 4 locations)", {
   ## epsilon should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   expect_equal(
-    apply(x, 1, mean), c(1, 1), tolerance = 0.05
+    rowMeans(x), c(1, 1), tolerance = 0.05
   )
 })
 
@@ -114,7 +114,7 @@ test_that("draw_epsilon produces expected results (>2 variants, 1 location)", {
 
   ## epsilon should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
-  expect_equal(apply(x, 1, mean), c(1, 1), tolerance = 0.05)
+  expect_equal(rowMeans(x), c(1, 1), tolerance = 0.05)
 })
 
 
@@ -260,7 +260,7 @@ test_that("estimate_advantage produces expected results (2 variants 3 locations)
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -287,7 +287,7 @@ test_that("estimate_advantage produces expected results (2 variants 1 location)"
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -313,13 +313,13 @@ test_that("estimate_advantage produces expected results (>2 variants 4 locs)", {
   ## as 2 epsilons are returned here.
 
   expect_equal(
-    apply(x$epsilon, 1, mean), c(1, 1), tolerance = 0.05
+    rowMeans(x$epsilon), c(1, 1), tolerance = 0.05
   )
 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -342,13 +342,13 @@ test_that("estimate_advantage produces expected results (>2 variants 1 loc)", {
 
   ## epsilon should be approximately 1
   expect_equal(
-    apply(x$epsilon, 1, mean), c(1, 1), tolerance = 0.05
+    rowMeans(x$epsilon), c(1, 1), tolerance = 0.05
   )
 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -433,13 +433,13 @@ test_that("estimate_advantage produces expected results (>2var, 1loc, imports)",
 
   ## epsilon should be approximately 0
   expect_equal(
-    apply(x$epsilon, 1, mean), c(0, 0), tolerance = 0.05
+    rowMeans(x$epsilon), c(0, 0), tolerance = 0.05
   )
 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -471,13 +471,13 @@ test_that("estimate_advantage produces expected results (>2var, 4loc, imports)",
 
   ## epsilon should be approximately 0
   expect_equal(
-    apply(x$epsilon, 1, mean), c(0, 0), tolerance = 0.05
+    rowMeans(x$epsilon), c(0, 0), tolerance = 0.05
   )
 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -510,7 +510,7 @@ test_that("estimate_advantage produces expected results (2var, 1loc, imports)", 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -546,7 +546,7 @@ test_that("estimate_advantage produces expected results (2var, 4loc, imports)", 
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R <- apply(x$R, c(1, 2), mean)
+  mean_R <- rowMeans(x$R, dims = 2)
   expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -644,9 +644,9 @@ test_that("estimate_advantage faster with precompute (2 variants 3 locations)", 
   ## R should be approximately 1 in both cases
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R1 <- apply(x1$R, c(1, 2), mean)
+  mean_R1 <- rowMeans(x1$R, dims = 2)
   expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
-  mean_R2 <- apply(x2$R, c(1, 2), mean)
+  mean_R2 <- rowMeans(x2$R, dims = 2)
   expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -683,9 +683,9 @@ test_that("estimate_advantage faster with precompute (2 variants 1 location)", {
   ## R should be approximately 1 in both cases
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R1 <- apply(x1$R, c(1, 2), mean)
+  mean_R1 <- rowMeans(x1$R, dims = 2)
   expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
-  mean_R2 <- apply(x2$R, c(1, 2), mean)
+  mean_R2 <- rowMeans(x2$R, dims = 2)
   expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -722,9 +722,9 @@ test_that("estimate_advantage faster with precompute (3 variants 4 locations)", 
   ## R should be approximately 1 in both cases
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R1 <- apply(x1$R, c(1, 2), mean)
+  mean_R1 <- rowMeans(x1$R, dims = 2)
   expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
-  mean_R2 <- apply(x2$R, c(1, 2), mean)
+  mean_R2 <- rowMeans(x2$R, dims = 2)
   expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
@@ -761,9 +761,9 @@ test_that("estimate_advantage faster with precompute (3 variants 1 location)", {
   ## R should be approximately 1 in both cases
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  mean_R1 <- apply(x1$R, c(1, 2), mean)
+  mean_R1 <- rowMeans(x1$R, dims = 2)
   expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
-  mean_R2 <- apply(x2$R, c(1, 2), mean)
+  mean_R2 <- rowMeans(x2$R, dims = 2)
   expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -144,7 +144,7 @@ test_that("draw_R produces expected results (2 variants, 4 locations)", {
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  expect_true(max(abs(x_mean[-c(1, 2, 3), ] - 1)) < 0.05)
+  expect_lt(max(abs(x_mean[-c(1, 2, 3), ] - 1)), 0.05)
 })
 
 
@@ -174,7 +174,7 @@ test_that("draw_R produces expected results (2 variants, 1 location)", {
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  expect_true(max(abs(x_mean[-c(1, 2, 3), ] - 1)) < 0.05)
+  expect_lt(max(abs(x_mean[-c(1, 2, 3), ] - 1)), 0.05)
 })
 
 
@@ -204,7 +204,7 @@ test_that("draw_R produces expected results (>2 variants, 4 locations)", {
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  expect_true(max(abs(x_mean[-c(1, 2, 3), ] - 1)) < 0.05)
+  expect_lt(max(abs(x_mean[-c(1, 2, 3), ] - 1)), 0.05)
 })
 
 
@@ -234,7 +234,7 @@ test_that("draw_R produces expected results (>2 variants, 1 location)", {
   ## R should be approximately 1
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
-  expect_true(max(abs(x_mean[-c(1, 2, 3), ] - 1)) < 0.05)
+  expect_lt(max(abs(x_mean[-c(1, 2, 3), ] - 1)), 0.05)
 })
 
 
@@ -261,7 +261,7 @@ test_that("estimate_advantage produces expected results (2 variants 3 locations)
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -288,7 +288,7 @@ test_that("estimate_advantage produces expected results (2 variants 1 location)"
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -320,7 +320,7 @@ test_that("estimate_advantage produces expected results (>2 variants 4 locs)", {
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -349,7 +349,7 @@ test_that("estimate_advantage produces expected results (>2 variants 1 loc)", {
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -440,7 +440,7 @@ test_that("estimate_advantage produces expected results (>2var, 1loc, imports)",
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -478,7 +478,7 @@ test_that("estimate_advantage produces expected results (>2var, 4loc, imports)",
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -511,7 +511,7 @@ test_that("estimate_advantage produces expected results (2var, 1loc, imports)", 
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -547,7 +547,7 @@ test_that("estimate_advantage produces expected results (2var, 4loc, imports)", 
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R <- apply(x$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -635,7 +635,7 @@ test_that("estimate_advantage faster with precompute (2 variants 3 locations)", 
   )
 
   ## t1 should be < t2
-  expect_true(t1[["elapsed"]] < t2[["elapsed"]])
+  expect_lt(t1[["elapsed"]], t2[["elapsed"]])
 
   ## epsilon should be approximately 1 in both cases
   expect_equal(mean(x1$epsilon), 1, tolerance = 0.05)
@@ -645,9 +645,9 @@ test_that("estimate_advantage faster with precompute (2 variants 3 locations)", 
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R1 <- apply(x1$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R1[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
   mean_R2 <- apply(x2$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R2[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -674,7 +674,7 @@ test_that("estimate_advantage faster with precompute (2 variants 1 location)", {
   )
 
   ## t1 should be < t2
-  expect_true(t1[["elapsed"]] < t2[["elapsed"]])
+  expect_lt(t1[["elapsed"]], t2[["elapsed"]])
 
   ## epsilon should be approximately 1 in both cases
   expect_equal(mean(x1$epsilon), 1, tolerance = 0.05)
@@ -684,9 +684,9 @@ test_that("estimate_advantage faster with precompute (2 variants 1 location)", {
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R1 <- apply(x1$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R1[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
   mean_R2 <- apply(x2$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R2[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -713,7 +713,7 @@ test_that("estimate_advantage faster with precompute (3 variants 4 locations)", 
   )
 
   ## t1 should be < t2
-  expect_true(t1[["elapsed"]] < t2[["elapsed"]])
+  expect_lt(t1[["elapsed"]], t2[["elapsed"]])
 
     ## epsilon should be approximately 1 in both cases
   expect_equal(mean(x1$epsilon), 1, tolerance = 0.05)
@@ -723,9 +723,9 @@ test_that("estimate_advantage faster with precompute (3 variants 4 locations)", 
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R1 <- apply(x1$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R1[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
   mean_R2 <- apply(x2$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R2[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 
@@ -752,7 +752,7 @@ test_that("estimate_advantage faster with precompute (3 variants 1 location)", {
   )
 
   ## t1 should be < t2
-  expect_true(t1[["elapsed"]] < t2[["elapsed"]])
+  expect_lt(t1[["elapsed"]], t2[["elapsed"]])
 
   ## epsilon should be approximately 1 in both cases
   expect_equal(mean(x1$epsilon), 1, tolerance = 0.05)
@@ -762,9 +762,9 @@ test_that("estimate_advantage faster with precompute (3 variants 1 location)", {
   ## not exactly 1 because of the first few timesteps & because of priors
   ## so ignore fisrt timesteps
   mean_R1 <- apply(x1$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R1[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R1[-c(1, 2, 3), ] - 1)), 0.1)
   mean_R2 <- apply(x2$R, c(1, 2), mean)
-  expect_true(max(abs(mean_R2[-c(1, 2, 3), ] - 1)) < 0.1)
+  expect_lt(max(abs(mean_R2[-c(1, 2, 3), ] - 1)), 0.1)
 })
 
 

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -839,13 +839,13 @@ test_that("estimate_advantage uses the correct t_min", {
   ## If t_min is 2, the first row if x$R will be NA
   expect_true(all(is.na(x$R[1, , ])))
   ## and not after that.
-  expect_true(! any(is.na(x$R[seq(2, dim(x$R)[1]), , ])))
+  expect_true(! anyNA(x$R[seq(2, dim(x$R)[1]), , ]))
   ## if t_min is NULL, t_min would be set to
   ## compute_t_min.
   t_min <- compute_t_min(incid, si_distr)
   x <- estimate_advantage(incid, si_distr, priors, seed = 1)
   expect_true(all(is.na(x$R[seq(1, t_min - 1, 1), , ])))
-  expect_true(! any(is.na(x$R[seq(t_min, dim(x$R)[1]), , ])))
+  expect_true(! anyNA(x$R[seq(t_min, dim(x$R)[1]), , ]))
 })
 
 

--- a/tests/testthat/test-weekly.R
+++ b/tests/testthat/test-weekly.R
@@ -133,10 +133,10 @@ test_that("estimate_R_agg works in parametric mode", {
   
   ## only check after the 10th common_t_start as before hand there is a lot of
   ## day to day variation
-  expect_true(all(relative_error[-c(1:20)] < 0.4)) # 0.4 arbitrarily small
-  expect_true(all(relative_error2[-c(1:20)] < 0.4)) 
-  expect_true(all(relative_error3[-c(1:20)] < 0.4)) 
-  expect_true(all(relative_error4[-c(1:20)] < 0.4)) 
+  expect_true(all(relative_error[-(1:20)] < 0.4)) # 0.4 arbitrarily small
+  expect_true(all(relative_error2[-(1:20)] < 0.4)) 
+  expect_true(all(relative_error3[-(1:20)] < 0.4)) 
+  expect_true(all(relative_error4[-(1:20)] < 0.4)) 
   
   ######################################################################
   ## test that the weekly R estimates from weekly data match exactly the weekly
@@ -255,10 +255,10 @@ test_that("estimate_R_agg works in non-parametric mode", {
   
   ## only check after the 10th common_t_start as before hand there is a lot of
   ## day to day variation
-  expect_true(all(relative_error[-c(1:20)] < 0.4)) # 0.4 arbitrarily small
-  expect_true(all(relative_error2[-c(1:20)] < 0.4)) 
-  expect_true(all(relative_error3[-c(1:20)] < 0.4)) 
-  expect_true(all(relative_error4[-c(1:20)] < 0.4)) 
+  expect_true(all(relative_error[-(1:20)] < 0.4)) # 0.4 arbitrarily small
+  expect_true(all(relative_error2[-(1:20)] < 0.4)) 
+  expect_true(all(relative_error3[-(1:20)] < 0.4)) 
+  expect_true(all(relative_error4[-(1:20)] < 0.4)) 
   
   ######################################################################
   ## test that the weekly R estimates from weekly data match exactly the weekly
@@ -332,7 +332,7 @@ test_that("estimate_R works with aggregated data in parametric mode", {
   
   ## only check after the 10th common_t_start as before hand there is a lot of
   ## day to day variation
-  expect_true(all(relative_error[-c(1:20)] < 0.4)) # 0.4 arbitrarily small
+  expect_true(all(relative_error[-(1:20)] < 0.4)) # 0.4 arbitrarily small
   
   ######################################################################
   ## test that the weekly R estimates from weekly data match exactly the weekly
@@ -408,7 +408,7 @@ test_that("estimate_R works with aggregated data in non-parametric mode", {
   
   ## only check after the 10th common_t_start as before hand there is a lot of
   ## day to day variation
-  expect_true(all(relative_error[-c(1:20)] < 0.4)) # 0.4 arbitrarily small
+  expect_true(all(relative_error[-(1:20)] < 0.4)) # 0.4 arbitrarily small
   
   ######################################################################
   ## test that the weekly R estimates from weekly data match exactly the weekly
@@ -727,8 +727,8 @@ test_that("method works with different single integers of dt", {
     res_weekly$R$`Mean(R)`[res_weekly$R$t_end %in% common_t_end_ten]
   
   ## lot of variation early on so excluding first part
-  expect_true(all(relative_error_three[-c(1:20)] < 0.4)) # 0.4 arbitrarily small
-  expect_true(all(relative_error_ten[-c(1:20)] < 0.5)) 
+  expect_true(all(relative_error_three[-(1:20)] < 0.4)) # 0.4 arbitrarily small
+  expect_true(all(relative_error_ten[-(1:20)] < 0.5)) 
   
 })
 

--- a/tests/testthat/test-weekly.R
+++ b/tests/testthat/test-weekly.R
@@ -500,7 +500,7 @@ test_that("r grid can be automatically updated with similar results", {
                                          config = config,
                                          method = method))
  
- expect_true(max(abs(res_weekly_small_grid$R - res_weekly_default_grid$R)) < 1e-9)
+ expect_lt(max(abs(res_weekly_small_grid$R - res_weekly_default_grid$R)), 1e-9)
   
 })
 

--- a/tests/testthat/test-weekly.R
+++ b/tests/testthat/test-weekly.R
@@ -31,10 +31,14 @@ test_that("function to aggregate incidence works", {
                "at least one value of dt should be an integer >=2")
   expect_error(aggregate_inc(SARS2003$incidence, -1L),
                "at least one value of dt should be an integer >=2")
-  expect_true(aggregate_inc(SARS2003$incidence, 7L)[1] == 
-                sum(SARS2003$incidence[1:7]))
-  expect_true(sum(aggregate_inc(SARS2003$incidence, dt_vec)[1:3]) == 
-                sum(SARS2003$incidence[1:7]))
+  expect_equal(
+    aggregate_inc(SARS2003$incidence, 7L)[1],
+    sum(SARS2003$incidence[1:7])
+  )
+  expect_equal(
+    sum(aggregate_inc(SARS2003$incidence, dt_vec)[1:3]),
+    sum(SARS2003$incidence[1:7])
+  )
 })
 
 

--- a/vignettes/alternative_software.Rmd
+++ b/vignettes/alternative_software.Rmd
@@ -59,7 +59,7 @@ df <- data.frame(Theme, Mod_type, APEestim, bayEStim, earlyR,
 
 knitr::kable(df, col.names = c("Theme","Modification Type","APEestim","bayEStim","earlyR",
                                "epicontacts","Epidemia","EpiFilter","EpiNow2"),
-             align = c("llccccccc"),
+             align = "llccccccc",
              format = "html") %>%
 kableExtra::kable_styling(font_size = 12,
                           full_width = T) %>%

--- a/vignettes/short_demo.Rmd
+++ b/vignettes/short_demo.Rmd
@@ -365,7 +365,7 @@ instance by the function `incidence` of the `incidence` package.
 Let's artificially create a line-list corresponding to our flu incidence data:
 
 ```{r line_list}
-dates_onset <- Flu2009$incidence$dates[unlist(lapply(1:nrow(Flu2009$incidence), function(i) 
+dates_onset <- Flu2009$incidence$dates[unlist(lapply(seq_len(nrow(Flu2009$incidence)), function(i) 
   rep(i, Flu2009$incidence$I[i])))]
 ```
 


### PR DESCRIPTION
This PR fixes some potential bugs or suboptimal code in terms of performance, as flagged by lintr.

As always, I recommend reviewing this PR commit by commit as each commit focuses on fixing one specific class of lint.

The change in the minimal R version in 86e11415197a5fd109fddc6fa8303bfd3f934887 does not have any functional effect because EpiEstim already *de facto* depends on R 3.5 by providing bundled version 3 binary `rda` files.

The lintr config used is saved in the last commit and the analysis done in this PR can be reproduced by running `lintr::lint_package()` in the package root.

If you wish, I can also set up lintr to automatically run as part of your continuous integration pipeline, alongside the existing R CMD check workflow.