### PR TITLE
Add lint-changed-files workflow

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,44 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  pull_request:
+    branches: [main, master]
+
+name: lint-changed-files
+
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::gh
+            any::lintr
+            any::purrr
+          needs: check
+
+      - name: Add lintr options
+        run: |
+          cat('\noptions(lintr.linter_file = ".lintr")\n', file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * estimate_R can now be applied to coarsely (non-daily) aggregated incidence data
 
+## MISC
+
+* lintr is now part of EpiEstim continuous integration toolkit, alongside R CMD check. This should detect and eliminate suboptimal code pattern and potential bugs before they even make it to `master` (#159, @Bisaloo).
+
 # EpiEstim 2.3
 
 * new function estimate_joint to estimate the transmission advantage of a strain or variant


### PR DESCRIPTION
Follow up of #158. This PR adds the `lint-changed-files` workflow to the continuous integration configuration. Files changed in PRs will be analyzed with lintr to detect suboptimal patterns and potential bugs.

**Checklist**
- ~~I have added tests to prove my changes work~~
- ~~I have added documentation where required~~
- [x] I have updated `NEWS.md` with a short description of my change
