### PR TITLE
Create a custom pkgdown reference index

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,6 @@
 ^doc$
 ^Meta$
 .lintr
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 inst/doc
 /doc/
 /Meta/
+docs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://mrc-ide.github.io/EpiEstim
+template:
+  bootstrap: 3
+

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,64 @@ url: https://mrc-ide.github.io/EpiEstim
 template:
   bootstrap: 3
 
+reference:
+  - title: Pre-processing
+    contents:
+    - aggregate_inc
+    - backimpute_I
+    - compute_si_cutoff
+    - compute_t_min
+    - discr_si
+    - first_nonzero_incid
+    - get_shape_R_flat
+    - get_shape_epsilon
+  - title: Estimation
+    contents:
+    - estimate_R
+    - estimate_R_agg
+    - estimate_advantage
+    - compute_lambda
+    - overall_infectivity
+    - process_I_multivariant
+    - wallinga_teunis
+  - title: Post-processing
+  - subtitle: MCMC diagnostics
+    contents:
+      - check_cdt_samples_convergence
+  - subtitle: Draw from posterior
+    contents:
+    - starts_with("draw_")
+    - sample_posterior_R
+  - title: Helpers
+  - subtitle: Default settings
+    contents:
+    - starts_with("default_")
+    - init_mcmc_params
+    - make_config
+    - make_mcmc_control
+  - subtitle: Plotting functions
+    contents:
+    - plot.estimate_R
+    - estimate_R_plots
+  - subtitle: Backwards-compatibility functions
+    contents:
+    - DiscrSI
+    - EstimateR
+    - OverallInfectivity
+    - WT
+  - subtitle: External package compatibility functions
+    contents:
+    - coarse2estim
+  - title: Datasets
+    contents:
+    - Flu1918
+    - Flu2009
+    - Measles1861
+    - MockRotavirus
+    - SARS2003
+    - Smallpox1972
+    - covid_deaths_2020_uk
+    - flu_2009_NYC_school
+    - mers_2014_15
+
+


### PR DESCRIPTION
This PR suggests the customisation of the [pkgdown reference index](https://mrc-ide.github.io/EpiEstim/) with custom sections. It should help users to find more easily the information they're looking for.

You may disagree with the way things are organized or I may have misunderstood the role of certain functions so feel free to adjust or suggest changes:

![image](https://github.com/user-attachments/assets/f6808991-682c-4e50-8ab2-88f4f929ba96)
