### PR TITLE
Fix pkgdown Github action 

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,28 +1,51 @@
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
 name: pkgdown
+
+permissions: read-all
+
 jobs:
   pkgdown:
-    runs-on: macos-latest
-    permissions:
-      contents: write
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-      - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
-      - name: Build and deploy website
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
+      - name: Upload website
+        uses: actions/upload-artifact@v4
+        with:
+          name: website
+          retention-days: 5
+          path: docs
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.7.2
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,46 +3,26 @@ on:
     branches:
       - main
       - master
-
 name: pkgdown
-
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: actions/checkout@v4
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
+          fetch-depth: 0
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+      - name: Build and deploy website
+        run: pkgdown::deploy_to_branch(new_process = FALSE)
         shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Deploy package
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
Closes #171.

* The GitHub Pkgdown action errors because the cache actions is out of date. 
* This PR updates the version as well as bringing the action more in line with current best practice. As well as this, it adds support for within PR running to avoid the error where we merge something to main that isn't working, it adds uploading the site as an object for checking and it adds a workflow dispatch trigger for checking. These are pulled from the Epinowcast actions.
* In the future I would suggest updating the pkgdown release mode to use auto but I think this is still safe enough as it is.

I have not updated the news as it is unclear to me if the current release is the dev news to be updated or linked to a release.

**How has this been tested**
I have added a trigger so that the action runs but doesn't deploy in a PR so we should see if it works here. I also made a dummy PR in my fork to test this: https://github.com/seabbs/EpiEstim/pull/1 see the action and the summary for the uploaded object for testing.

**Checklist**
- [ ] I have added tests to prove my changes work
- [ ] I have added documentation where required
- [ ] I have updated `NEWS.md` with a short description of my change
